### PR TITLE
correctly determine getRootPath for non-CLI version

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,9 @@ const sidebar = {
 };
 
 
-getRootDir = function () {
-    return path.resolve(process.cwd());
+getRootDir = function () { 
+    const extraPath = (process.argv.length > 3) ? `/${process.argv[3]}` : '';
+    return path.resolve(process.cwd() + extraPath);
 };
 
 getSidebarItems = function (dir, root) {


### PR DESCRIPTION
#1 Fixes determining root path for purpose of finding `.vuepress/config.js` and generating menu items based on structure